### PR TITLE
Updates to Documentation

### DIFF
--- a/docs/EVENT README.txt
+++ b/docs/EVENT README.txt
@@ -27,6 +27,7 @@ The purpose of "Event Arg" varies depending on the value of "Event Index".
 
 The "Flags" values are mostly unknown, but the 1st value controls collision and the 3rd value adjusts the maximum distance that trainers will go to intercept the player when entering line of sight.
 When set to 0, the player will need to explicitly interact with the trainer to begin the battle.
+Flag 4 is an auto-trigger flag. Use with flag 1 set to 0 and it'll trigger when stepped on.
 
 "Movement Mode" values:
 0: static, 1: face down, 2: face left, 3: face right, 4: face up

--- a/docs/EVENT README.txt
+++ b/docs/EVENT README.txt
@@ -31,5 +31,6 @@ When set to 0, the player will need to explicitly interact with the trainer to b
 "Movement Mode" values:
 0: static, 1: face down, 2: face left, 3: face right, 4: face up
 5: look around, 6: wander, 7: run around, 8: face player
-9: intercept player, 11: look away from player, 12: avoid player
-13: run from player, 14: spin counter-clockwise, 15: spin clockwise
+9: intercept player, 10: run and intercept player, 11: look away from player,
+12: avoid player, 13: run from player, 14: spin counter-clockwise,
+15: spin clockwise, 16: causes dialogue click sounds? Probably don't use, 17: follow player

--- a/docs/EVS SCRIPT README.txt
+++ b/docs/EVS SCRIPT README.txt
@@ -1,6 +1,6 @@
 .evs scripts each contain 32 10-field entries to be executed sequentially.
 The first field of each entry determines the type of operation for that entry.
-A list of known values (in hexadecimal) is given below, courtesy of OmegaBloodmoon.
+A list of known values (in hexadecimal) is given below; original list courtesy of OmegaBloodmoon, expanded upon by Patri.
 
 1: Action done by the player (Move, jump, emotion bubbles, etc...)
 2: Same except for objects on the map
@@ -10,27 +10,400 @@ A list of known values (in hexadecimal) is given below, courtesy of OmegaBloodmo
 6: Enables/disables a flag
 7: Stops the current event and loads another one
 8: Enables/Disables an object on the map
-9: Flag test (If flag is enabled, keeps reading the next chunk normally, otherwise skips to chunk x, first chunk being chunk 0)
-a: Works with b to make shadings, pictures, etc... Not sure how it works since I only need to make a black screen
-b: ^
-c: Battle puppet
-d: Battle trainer
-e: Battle puppet? Prob has specifics that diferentiate it from c, but didn't look into it much
-f: Enables trainer. After a trainer is beaten, it can't be fought again. Even if an event should load his battle, it won't. So you need f to reenable it. Not sure if it also reenables trainers on the map, only tested with event trainers.
-10/11/12: The only notes I have for those is "TEST" so either it looks like a test of some kind, or I put a note to make tests about it. Not sure since I don't remember where I saw those.
+9: Flag test (If flag is false, keeps reading the next chunk normally, otherwise skips to chunk x, first chunk being chunk 0)
+A: Screen fade
+B: Display images
+C: Battle Puppet
+D: Battle trainer
+E: Battle starter
+F: Toggles trainer. After a trainer is beaten, it can't be fought again, even via events.
+10: Name Change
+11: Gender Change
+12: Choose Puppet
+13: Give Puppet
 14: Gives item
 15: Removes item
 16: Item tests (Functions about the same way as 9)
-Starting from here I'm unsure about the effects since I never tested them, but it's what it's probably doing
 17: Plays music
+18: Plays sound effect
 19: Puppet box
-1d: Team heal
-22: Pvp hub
-25: Save?
-26/27: I labeled both as "Hina?" so either of them is probably the seal break
-28: Credits?
-2f: Calls a list
-45: Special battle. Not sure what exactly is different from a normal puppet battle, but this one is used for lv99 NLily battle so...
-Considering the highest one I found is 45, and if we say that all values below that are used, that makes a LOT of unknown events
+1A: Change object behavior
+1B: Direction Test
+1C: Shop
+1D: Team heal
+1E: ??? -- Seems to just be broken
+1F: Check Puppet Book completion
+20: Teleport object
+21: Fullscreen text
+22: PvP hub
+23: Reincarnation
+24: Toggle Gap Map Spot
+25: Save
+26: Choose favorite
+27: Randomize favorite
+28: Credits
+29: Release Puppet
+2A: Costume menu
+2B: Toggle money display
+2C: Check money (Works about the same as 9)
+2D: Subtract money
+2E: Random branch
+2F: Calls a list
+30: Follower lock
+31: Rental team
+32: Limit steps
+33: Cancel steps limit
+34: Set HVT Trainer
+35: Reset Winstreak
+36: Increment Winstreak
+37: Check Winstreak
+38: Fight HVT Trainer
+39: ??? -- Needs Research
+3A: ??? -- Needs Research
+3B: Change map weather
+3C: ??? -- Needs Research
+3D: ??? -- Needs Research
+3E: ??? -- Needs Research
+3F: Update Winstreak
+40: HVT Validity Check
+41: Forced Save
+42: HVT Rewards
+43: Previous favorite check
+44: Load starter
+45: Uncatchable Battle
+46: Post-game Credits
 
-(Editors note: the lvl 99 lily is uncatchable, so 45 might be for uncatchable puppets)
+=============================================================================================
+In-depth documentation:
+(Big Special Thanks to OmegaBloodmoon, and AtaeKurri by extension, for a lot of information on multiple of these!)
+
+100 + event ID: Runs event without waiting for them to finish. Allows for running multiple event lines at the same time.
+A simultaneous event will run itself and any other simultaneous events below it, until it runs into an event that does wait.
+	
+Event syntax:
+The events are written as they would be in the Event Scripts editor. For the sake of viewing the event files in a hex editor, each field is two bytes; field 1 is the first two bytes, field 2 is the next two bytes... so on, so forth.
+Note for the sake of hex editing: the fields are in little endian; byte pairs are stored OPPOSITE of how they'd be read.
+e.g.: 0x1234 would be stored as 0x34, followed by 0x12.
+
+1: Player Actions
+	1, [Action], [Facing Direction], [Count], 0, [Extra Parameter]
+	
+	Action List (Shared with Object Actions):
+	0 = Nothing
+	2 = Turn Around
+	3 = Wait
+	4 = Nothing?/Also wait?
+	5 = Emote [Uses Extra Parameter; see below]
+	6 = Run in place
+	7 = Jump in place
+	8 = Counter-clockwise spin around
+	9 = Clockwise spin around
+	A = Toggle visibility (Hitbox stays)
+	B = Toggle bicycle (Player-Only)
+	C = Animate and vanish (Breakable Rocks and Cuttable Trees. Hitbox disappears)
+	D = Walk
+	E = Run
+	F = Fast Walk?
+	10 = Walk backwards
+	11 = 2-Tile Jump
+	12 = Enter Boat (Player-Only)
+	13 = 1-tile Jump (Player-Only)
+	14 = Running Bump 
+	15 = Face Player / Face Left, if Player
+	16 = Slow walk in place
+	17 = Gap Map animation + Toggle Player's visibility (Player-Only)
+	18 = FAST Run (Object-Only, ignores collision)
+	19+ = Crashes the game
+	
+	Facing Direction List:
+	0 = Don't Update
+	1 = Down
+	2 = Left
+	3 = Right
+	4 = Up
+	5 = Away from Current
+	6+ = Away from Current - just use 5
+
+	Extra Parameters:
+		Emote:
+		0 = ??
+		1 = Exclamation
+		2 = Question
+		3 = Smile
+		4 = Sweatdrop
+		5 = Lightbulb
+		6 = Note
+		7 = Heart
+		8 = Blush
+		9 = Sleep
+		A = ...
+		B = Annoyed
+		C = Anger Vein
+		D = Exclamation (No Sound)
+		E = Sparkles
+		F = MG (Chewing)
+		10 = Neutral Face
+		11 = Wink
+		12 = Stare
+		13 = Very Happy
+		14 = NONE
+	
+2: Object Actions
+	2, [Action], [Facing Direction], [Count], [Object ID], [Extra Parameter]
+	
+	Object ID Specials (Can be used as Target Object in other Event Types):
+	0 = Self
+	892 (0x37C) = Player's Puppet
+	1024 (0x400) = Player (Applies to other objects' targets, but can't be used to make the player do things directly. Use event type 1 for player actions)
+	
+3: Camera Control
+	3, [Camera Mode], [Scroll Speed - Higher is faster], [Tile Count], [Target Object]
+	
+	Camera Modes:
+		1 = Down
+		2 = Left
+		3 = Right
+		4 = Up
+		5 = Does nothing
+		6 = Center on Player (Default)
+		7 = Center on Object
+	
+	If using a target object, set Tile Count to a non-zero value.
+		
+4: Warps
+	4, [Map ID. 0 = Self], [Target Object], [Facing Direction], [Transition Type], [Silent Warp flag]
+	
+		Transition Types:
+		0 = Full-screen Fade to and from Black
+		1 = Directional Fade + Walk Forward
+		2 = Flip Screen
+		
+	Note: What Collision Layer the player is on after a warp depends on what layer the Target Object's on.
+	
+5: Dialogue
+	5, [Text ID], [1 = Yes/No Prompt], [Line to skip to if No is picked]
+
+6: Flag Toggle
+	6, [Flag ID], [0 = False / 1 = True]
+
+7: Event Trigger
+	7, [Built-in Flag Check. 1 = Always Load - Otherwise, load if Flag is True], [New Event ID]
+	
+8: Object Toggle
+	8, [Map ID. 0 = Self], [Object ID. 0 = Self], [0 = Disabled / 1 = Enabled]
+	
+9: Flag Check
+	9, [Flag ID], [Line to Skip to if Flag is True]
+
+A: Screen Fade
+	A, [0 = Black / 1 = White], [Opacity: 00-FF], [Fade Speed. Higher is faster]
+
+B: Display Image
+	B, [Image ID], [Fade Speed. Higher is faster], [Opacity]
+	
+	Images are loaded from gn_dat5.arc/graph.
+	
+C: Puppet Battle
+	C, [Puppet ID], [Line to Skip to on Win - 0x21 defaults to next], [Line to Skip to on Loss - 0x21 defaults to blackout], [Style], [Level]
+
+D: Trainer Battle
+	D, [Trainer ID], [Line to Skip to on Win - 0x21 defaults to next], [Line to Skip to on Loss - 0x21 defaults to blackout]
+
+E: Starter Battle
+	E
+	
+		Utilizes event 44 to load its data. Loads nothing, not even NULL/ID 0, on its own.
+		Starter is locked to Level 5, Normal style.
+
+F: Trainer Toggle
+	F, [Trainer ID], [0 = Not Fought, 1 = Fought]
+	
+10: Name Change
+	10, [What to Name]
+		What to name:
+		0: Player
+		1: Puppet (Defined through Event 12)
+		2: Box (Not Defined)
+
+11: Player Gender Change
+	11
+	
+	The change in the Player's sprite is instantaneous, so hiding it or using a screen fade is recommended.
+	Prompt's text is baked into gn_dat1.arc/common/message/SexSelectMessage.txt
+
+12: Puppet Choice
+	12, [Line to Skip to on back out]
+
+	Used for selecting a Puppet in your party to be the target of other events. Required by:
+	ID 10 (Name Change), ID 29 (Release Puppet), ID 2A (Costume Change)
+	
+13: Give Puppet
+	13, [Puppet ID], [Style], [Level], [Unknown], [Line to Skip to after execution - 0x21 continues to next line]
+	
+		If Event type 44 is executed before, and Puppet ID is set to 0, gives starter instead.
+		Style and level arguments are completely ignored; giving a starter always gives the favorite at level 5, Normal Style, all ranks at S, Heart Mark and Dream Shard/Boundary Trance equipped.
+
+14: Give Item
+	14, [Item ID], [Count], [Line to Skip to if max exceeded - 0x22 shows default message and ends event], [Hide Message Box Flag]
+	
+15: Take Item
+	15, [Item ID], [Count]
+	
+16: Item Check
+	16, [Item ID], [Count], [Line to Skip to on Fail]
+	
+17: Switch Background Music
+	17, [Music ID], 0
+	Setting the 3rd field to 1 causes a softlock. The game probably tries to wait, much like with Sound Effects.
+	Set Music ID to 10000 (0x2710) to reset it to the map's default.
+	
+18: Play Sound Effect
+	18, [Sound ID], [0 = Proceed to next line immediately / 1 = Wait for SFX to end first]
+
+19: Puppet Box
+	19
+
+1A: Change Object Behavior
+	1A, [Object ID. 0 = Self], [Behavior], [Movement Speed. 0 = Unchanged; 0x100 = 0. Lower is faster]
+
+	The object's behavior will only remain changed as long as the map isn't changed and the player doesn't save and reload.
+	Behavior and movement speed values are exactly the same as in the Map Editor.
+
+1B: Direction Check
+	1B, [Object ID. 0 = Self], [Jump if Facing Down], [Jump if Facing Left], [Jump if Facing Right], [Jump if Facing Up]
+	Setting any of the 3rd, 4th, 5th or 6th field to 0x21 advances execution to the next line.
+	
+1C: Open Shop
+	1C, [Shop ID]
+
+	Shops are configurable from gn_dat5.arc/script/shop.
+	
+1D: Team Heal
+	1D, [Heal Type]
+		0: Heal SFX
+		1: Silent
+		2: Fade to Black + Jingle
+		3+: Softlock
+	
+1E: ??? Messes with transparencies?? Seems to be a broken event. Do not use?
+	1E, [Makes transparency white??]
+
+1F: Puppet Book Check
+	1F, [Puppet Count], [Line to Skip to if not enough Puppet types caught]
+
+20: Teleport object
+	20, [Object ID], [Target X Pos], [Target Y Pos], [Always 2?]
+	
+21: Fullscreen Text
+	21, [Text ID], [Print Speed Modifier. Lower is faster; 0 = Instant]
+
+22: Online Play Menu
+	22
+
+23: Reincarnation Menu
+	23
+
+24: Enable/Disable Gap Map Locations
+	24, [Map ID], [0 = Disable, 1 = Enable]
+
+25: Forced Save
+	25
+
+26: Starter Choice
+	26, [Line to Skip to on Cancel]
+	
+27: Randomize Starter
+	27
+
+28: Credits
+	28
+
+29: Release Puppet [Uses 12 to select Puppet]
+	29, [Line to Skip to if trying to release last Puppet in party]
+
+2A: Costume Change [Uses 12 to select Puppet]
+	2A, [Line to Skip to on Cancel]
+
+2B: Toggle Money Display
+	2B
+
+2C: Money Check
+	2C, [Count], [Line to Skip to if money's too low]
+
+2D: Take Money
+	2D, [Count]
+
+2E: Random Branch, 2 outcomes
+	2E, [Probability of Success. 1 = 50/50, higher seems to decrease it], [Line to Skip to if chance succeeds]
+
+2F: List Trigger
+	2F, [Text ID], [List ID]
+	
+	Lists handle any prompt more complex than a simple Yes/No.
+	Lists are configurable from gn_dat5.arc/script/list.
+	Backing out of a list always picks the bottommost option.
+	
+30: Lock/Unlock Followers
+	30, [1 = Lock, 0 = Unlock]
+
+	Affects both the following Puppet and any object with behavior type 17 (Follow Player).
+	
+31: Preset Teams
+	31, [Team ID]
+
+	Do note, this REPLACES the current team. Any Puppets the Player currently has in their team will be lost.
+	Preset Team Puppets work and behave just like any other Puppet.
+	
+32: Start Step Count
+	32, [Step Count], [Event ID to trigger once said steps are taken]
+
+33: Stop Step Count
+	33
+	
+34-38: HVT Events. See Omega's HVT Doc [Or here, if they add on the info].
+
+39: ??? - Currently Unknown
+
+3A: ??? - Currently Unknown
+
+3B: Switch Map Effect
+	3B, [Map ID], [Effect ID]
+
+	Weather/Effect List:
+	0: None
+	1: Darkness
+	2: Fog
+	3: Red Fog
+	4: Snow
+	5: Cherry Blossoms
+	6: Heat
+	7: Spirits?
+	8: Light Orbs
+	9: Rain
+	
+	Replaces the effect for the map in question PERMANENTLY, until changed again via this event. Carries over between map transitions and save & reloads.
+
+3C: ??? - Currently Unknown
+
+3D: ??? - Currently Unknown
+
+3E: ??? - Currently Unknown
+
+3F-40: HVT Events. See Omega's HVT Doc [Or here, if they add on the info].
+
+43: Check Starter Match (New Game+)
+	43: 43, [Line to Skip to if Current starter = Last run's starter]
+	
+	Omega: "Seems to check if your chosen favorite is the same as your previous playthrough"
+
+44: Load Starter
+	44
+		
+		Required by Event type E, and can be used by Event type 13 to give a starter. Probably necessary due to the Human Village Tournament, and the starter having either a Dream Shard or a Boundary Trance depending on it.
+
+45: Uncatchable, Unfleeable Puppet Battle
+	45, [Puppet ID], [Line to Skip to on Win - 0x21 defaults to next], [Line to Skip to on Loss - 0x21 defaults to blackout], [Style], [Level]
+		
+		Exactly the same as Event Type C, but the Puppet is uncatchable and you can't run away from the fight. You can, however, use a Plain Doll to flee. This is counted as a win.
+	
+46: Post-Game Credits

--- a/docs/file_formats/charaStandCheck.txt
+++ b/docs/file_formats/charaStandCheck.txt
@@ -1,0 +1,17 @@
+TPDP: N/A. File only found in YnK.
+YnK: gn_dat1.arc/talkImage/stand/charaStandCheck.bin
+This file is an array of 1-byte bools indicating what portraits should be loaded.
+They form groups of 12. One for each portrait, 12 per character.
+You will need to use a hex editor to set these accordingly if you add new characters to the game.
+Puppets and trainer fights ignore this file, but it is necessary for using new portraits in dialogue files.
+
+0x00: 000_00.png
+0x0C: 001_00.png
+0x0D: 001_01.png
+0x0E: 001_02.png
+...
+0x18: 002_00.png
+0x19: 002_01.png
+0x1A: 002_02.png
+...
+So on, so forth.

--- a/docs/file_formats/chp.txt
+++ b/docs/file_formats/chp.txt
@@ -1,9 +1,53 @@
-.chp files contain information about the animations for a tileset.
-it contains an array of 26-byte structures.
-the json generated for this one is purely informational as all it does is map linear addresses to the index of the first frame of animation on the sprite sheet.
-this is mostly useful for rendering .fmf files.
+.chp files contain information about the animations and properties of the tiles of a tileset.
 
----BINARY FORMAT---
-                             _
-0x00: u8 index of first frame |
-0x01-0x19: ???               _|--0x1A
+Each .chp contains an array of 256 sets of 26 (0x1A) bytes each.
+.png of corresponding tileset contains 256 tiles arranged in 32 rows of 8 tiles each. Each tile is a visual ID.
+Both together are used to display maps and tell the game what each tile's properties are.
+
+Clicking on a visual tile in the Map Editor will highlight the corresponding tile's first frame, while displaying the tile's functional ID in the Value field.
+
+the json generated for this one is purely informational as all it does is map linear addresses to the index of the first frame of animation on the sprite sheet.
+
+ID of each visual tile can be calculated by hand, not too differently from dollIcon.png:
+- Each odd row, start from X0 and count up.
+- Each even row, start from X8 and count up.
+- Every 2 rows, increase X by 1.
+e.g. 5th row, 3rd tile:
+5th row = Start at 20. 3rd tile = 20+2 = 0x22
+
+To find the start of what tile you're looking for: Take the tile ID provided by the Map Editor, multiply by 1A (26 in decimal)
+e.g. Value 41 = 41*26 = 1066 = 0x42A
+
+Offsets, per object:
+0x00: Visual/display ID - Doesn't need to match the Tile's actual ID.
+0x01-0x03: Extra Display IDs to use as Frames. Up to 3 total, not counting offset 0x00's. Optional
+0x04: Encounters
+	= 0x00: No Encounters
+	= 0x01: Yes - Normal Encounters
+	= 0x03: Yes - Blue Grass Encounters
+0x05: Animation Type
+	= 0x00: No Animation
+	= 0x01: Always looping
+	= 0x02: When stepped on, then reset to first frame
+	= 0x03: When tile below's stepped on, then reset to first frame
+	= 0x04: When stepped on, then animate back on exiting tile (Uses offset 0x0C for sounds)
+	= 0x05: When tile below's stepped on, then animate back on exiting said tile (Used for door tops)
+0x06-0x08: If not 0, animations don't play. Some suspicion the three may be some sort of conditional? Or at least linked.
+Always 0 on all vanilla tilesets.
+0x09: Particles and Sound Effects
+	= 0x01: Green Leaves + Sounds (SFX only if Animation Type = 02
+	= 0x02: Pink Leaves
+	= 0x03: Lower Pink Leaves?
+	= 0x04: Water Ripple + SFX (requires transparency; SFX only if not on boat)
+	= 0x05: Create Dirt Footprints
+	= 0x06: Create Snowy Footprints
+	= 0x07: Nothing?
+	= 0x08: Emit Glow (Center of Tile)
+	= 0x09: Emit Glow (Bottom of Tile)
+	= 0x0A: Remove Geometry Layer 1?
+0x0A: Animation Speed (Lower is faster)
+0x0B: Number of Animation Frames
+0x0C: Animation Mode 04 - Sound Effect. Made on entering and on leaving
+	= 0x01: Swinging door
+	= 0x02: Sliding door
+0x0D-0x19 [Half the set]: Seemingly completely unused. Don't seem to do anything, and always 0 on all vanilla tilesets.


### PR DESCRIPTION
- Expanded upon EVS SCRIPT README's event list
- Added in-depth guide on event parameters to EVS SCRIPT README
- Extended EVENT README's movement mode values; some were missing
- file_formats/chp actually has information now
- Added file_formats/charaStandCheck. No real harm to documenting how to edit this file, right?